### PR TITLE
Use snprintf for safe dimension string formatting

### DIFF
--- a/src/C/NDfield.c
+++ b/src/C/NDfield.c
@@ -266,14 +266,17 @@ int Save_NDfield(NDfield *field,const char *filename)
   FILE *f;
 
   char dims_msg[255];
-  sprintf(dims_msg,"[%d",field->dims[0]);
-  for (i=1;i<field->n_dims;i++) sprintf(dims_msg,"%s,%d",dims_msg,field->dims[i]);
-  sprintf(dims_msg,"%s]",dims_msg);
+  int offset = snprintf(dims_msg, sizeof(dims_msg), "[%d", field->dims[0]);
+  for (i = 1; i < field->n_dims && offset < (int)sizeof(dims_msg); i++)
+    offset += snprintf(dims_msg + offset, sizeof(dims_msg) - offset, ",%d", field->dims[i]);
+  snprintf(dims_msg + offset, sizeof(dims_msg) - offset, "]");
   
   char msg[255];
   print_dataType(msg,field->datatype);
-  if (field->fdims_index!=0) sprintf(msg,"%s coords",msg);
-  else sprintf(msg,"%s array",msg);
+  if (field->fdims_index!=0)
+    snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg), " coords");
+  else
+    snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg), " array");
   printf ("Saving %s %s to file %s ...",dims_msg,msg,filename);
   fflush(0);
 
@@ -1131,14 +1134,17 @@ NDfield *Load_NDfield(const char *filename)
   field = Create_NDfield(dims,ndims,fdims_index,datatype,x0,delta,NULL,comment);
   
   char dims_msg[255];
-  sprintf(dims_msg,"[%d",dims[0]);
-  for (i=1;i<field->n_dims;i++) sprintf(dims_msg,"%s,%d",dims_msg,dims[i]);
-  sprintf(dims_msg,"%s]",dims_msg);
-  
+  int offset = snprintf(dims_msg, sizeof(dims_msg), "[%d", dims[0]);
+  for (i = 1; i < field->n_dims && offset < (int)sizeof(dims_msg); i++)
+    offset += snprintf(dims_msg + offset, sizeof(dims_msg) - offset, ",%d", dims[i]);
+  snprintf(dims_msg + offset, sizeof(dims_msg) - offset, "]");
+
   char msg[255];
   print_dataType(msg,datatype);
-  if (fdims_index!=0) sprintf(msg,"%s coords",msg);
-  else sprintf(msg,"%s array",msg);
+  if (fdims_index!=0)
+    snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg), " coords");
+  else
+    snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg), " array");
   printf ("Loading %s %s from file %s ...",dims_msg,msg,filename);
   fflush(0);
 

--- a/src/mse/NDfield_interface.hxx
+++ b/src/mse/NDfield_interface.hxx
@@ -49,6 +49,7 @@
 
 #include <string>
 #include <limits>
+#include <cstdio>
 
 #include "NDfield.h"
 #include "NDfield_VTK_IO.h"
@@ -212,9 +213,10 @@ namespace ndfield {
 	}
       
       char dimstr[256];
-      sprintf(dimstr,"[%d",dims[0]);
-      for (i=1;i<(long)dims.size();i++) sprintf(dimstr,"%s,%d",dimstr,dims[i]);
-      strcat(dimstr,"]");
+      int offset = snprintf(dimstr, sizeof(dimstr), "[%d", dims[0]);
+      for (i = 1; i < (long)dims.size() && offset < (int)sizeof(dimstr); i++)
+        offset += snprintf(dimstr + offset, sizeof(dimstr) - offset, ",%d", dims[i]);
+      snprintf(dimstr + offset, sizeof(dimstr) - offset, "]");
       if (verbose>=1) printf("Reading %s %s from NDfied ASCII file '%s' ... ",dimstr,coord?"coords":"grid",fname.c_str());
       fflush(0);
       


### PR DESCRIPTION
## Summary
- avoid buffer overflow when printing dimension lists by switching from `sprintf` to `snprintf`
- append coordinate/array suffixes using bounded writes
- include `<cstdio>` in NDfield interface header

## Testing
- `make -j4`
- `./build/src/mse/fieldconv data/simu_2D.ND -info`


------
https://chatgpt.com/codex/tasks/task_e_685d581551c883279f9f04a04d582d14